### PR TITLE
FMS cobrand example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ packer/boxes/*
 !packer/boxes/README.md
 packer/iso/*
 !packer/iso/README.md
+packer/files/*
+!packer/files/README.md

--- a/docs/fixmystreet.md
+++ b/docs/fixmystreet.md
@@ -64,6 +64,35 @@ You could store a copy of our configuration file in a secure location and have
 a script copy this into the right place and ensure the permissions were correct
 when you launch an instance.
 
+## Adding your own cobrand
+
+If you want to build a custom AMI with [your own cobrand](https://fixmystreet.org/customising/)
+baked in, we've provided a variation on our standard builder to cater for this.
+
+First, create a directory under `files/` called `cobrand` and place your cobrand
+files into it.
+
+For example, if you maintain your cobrand in its own repository you could clone
+a working copy as this directory.
+
+Regardless of how you populate this, it should consist of something like the
+following (all items optional):
+
+```
+files/cobrand/
+    templates/web/(cobrand)/
+    templates/email/(cobrand)/
+    perllib/FixMyStreet/Cobrand/(CoBrand.pm)
+    web/cobrands/(cobrand)/
+```
+
+Next, create a suitable configuration file and place this at `files/general.yml.cobrand`.
+
+Finally you should be able to run `make fixmystreet-ami-cobrand` and the cobrand
+files will be included and activated during the build process. This target uses
+the `amazon_fms_cobrand.json` builder definition which will build a private AMI
+by default. It will be named `fixmystreet-installation-full-cobrand-YYYY-MM-DD`.
+
 ## Building a slim AMI
 
 **This process is under development and subject to change.**

--- a/docs/fixmystreet.md
+++ b/docs/fixmystreet.md
@@ -37,9 +37,16 @@ For example:
       ]
     },
     {
-      "destination": "/var/www/fixmystreet/fixmystreet/conf/general.yml",
-      "source": "./general.yml",
-      "type": "file"
+      "type": "file",
+      "source": "./files/general.yml",
+      "destination": "/tmp/general.yml"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sudo mv /tmp/general.yml /var/www/fixmystreet/fixmystreet/conf/general.yml",
+        "sudo chown {{user `site_user`}}:{{user `site_user`}} /var/www/fixmystreet/fixmystreet/conf/general.yml"
+      ]
     }
   ]
 }

--- a/packer/Makefile
+++ b/packer/Makefile
@@ -22,6 +22,11 @@ fixmystreet-ami-slim:
 	@echo "Building App-only FixMyStreet AMI..."
 	packer build -var-file vars/fixmystreet.json -var 'install_args=--docker' -var 'install_type=slim' builders/amazon.json
 
+fixmystreet-ami-cobrand:
+	@test -d files/cobrand || ( echo "Please make sure you've got a cobrand at files/cobrand/" && exit 1 )
+	@test -f files/general.yml.cobrand || ( echo "Please make sure you've got a suitable config file at files/general.yml.cobrand" && exit 1 )
+	packer build -var-file vars/fixmystreet.json -var 'install_type=full-cobrand' builders/amazon_fms_cobrand.json
+
 fixmystreet-vagrant-stretch:
 	@echo "Building FixMyStreet Vagrant box..."
 	packer build -var-file=vars/stretch.json -var-file=vars/fixmystreet.json builders/vagrant_debian.json

--- a/packer/builders/amazon_fms_cobrand.json
+++ b/packer/builders/amazon_fms_cobrand.json
@@ -1,0 +1,68 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "site_name":      "",
+    "site_user":      "",
+    "install_args":   "--default",
+    "install_type":   "full",
+    "region":         "eu-west-1"
+  },
+  "sensitive-variables": [
+    "aws_access_key",
+    "aws_secret_key"
+  ],
+  "builders": [
+    {
+      "access_key":    "{{user `aws_access_key`}}",
+      "ami_name":      "{{user `site_name`}}-installation-{{user `install_type`}}-{{isotime \"2006-01-02\"}}",
+      "tags": {
+        "Name": "{{user `site_name`}}-installation-{{user `install_type`}}-{{isotime \"2006-01-02\"}}"
+      },
+      "instance_type": "m3.medium",
+      "region":        "{{user `region`}}",
+      "secret_key":    "{{user `aws_secret_key`}}",
+      "ssh_username":  "admin",
+      "type":          "amazon-ebs",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "name":                "debian-stretch-hvm-x86_64-gp2-*",
+          "root-device-type":    "ebs"
+        },
+        "owners":      [ "379101102735" ],
+        "most_recent": true
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "curl -L -O https://raw.github.com/mysociety/commonlib/master/bin/install-site.sh",
+        "sudo -E sh install-site.sh {{user `install_args`}} {{user `site_name`}} {{user `site_user`}} 2>&1"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "files/cobrand",
+      "destination": "/tmp"
+    },
+    {
+      "type": "file",
+      "source": "files/general.yml.cobrand",
+      "destination": "/tmp/general.yml"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sudo mv /tmp/cobrand /var/www/fixmystreet/",
+        "sudo chown -R {{user `site_user`}}:{{user `site_user`}} /var/www/fixmystreet/cobrand",
+        "sudo mv /tmp/general.yml /var/www/fixmystreet/fixmystreet/conf/general.yml",
+        "sudo chown {{user `site_user`}}:{{user `site_user`}} /var/www/fixmystreet/fixmystreet/conf/general.yml",
+        "sudo su {{user `site_user`}} -c '/var/www/fixmystreet/fixmystreet/bin/docker-cobrand'",
+        "sudo su {{user `site_user`}} -c '/var/www/fixmystreet/fixmystreet/script/update'"
+      ]
+    }
+  ]
+}

--- a/packer/files/README.md
+++ b/packer/files/README.md
@@ -1,4 +1,4 @@
 # Files
 
-This directory is set aside for things do be uploaded using the `file` provisioner,
+This directory is set aside for things to be uploaded using the `file` provisioner,
 for example the configuration and cobrand files needed to skin a FixMyStreet image.

--- a/packer/files/README.md
+++ b/packer/files/README.md
@@ -1,0 +1,4 @@
+# Files
+
+This directory is set aside for things do be uploaded using the `file` provisioner,
+for example the configuration and cobrand files needed to skin a FixMyStreet image.


### PR DESCRIPTION
This includes a builder definition that can be used to create an AMI with a cobrand included, together with some documentation outlining its usage.